### PR TITLE
fix: make output directory relative to project directory

### DIFF
--- a/stuart/src/main.rs
+++ b/stuart/src/main.rs
@@ -59,7 +59,7 @@ fn app() -> App<'static> {
                     Arg::new("output")
                         .long("output")
                         .short('o')
-                        .help("Output directory")
+                        .help("Output directory (if relative, relative to the manifest file)")
                         .default_value("dist"),
                 ),
         )
@@ -76,7 +76,7 @@ fn app() -> App<'static> {
                     Arg::new("output")
                         .long("output")
                         .short('o')
-                        .help("Output directory")
+                        .help("Output directory relative to the manifest file")
                         .default_value("dist"),
                 ),
         )


### PR DESCRIPTION
The `dev` command was not following this convention so with certain configurations (running the command outside of the project directory) it would fail to serve files.